### PR TITLE
Set TEST_MODE true for dev envs

### DIFF
--- a/python/src/pipeline/util.py
+++ b/python/src/pipeline/util.py
@@ -50,6 +50,8 @@ def _get_task_target():
   # Break circular dependency.
   # pylint: disable=g-import-not-at-top
   import pipeline
+  if os.environ['SERVER_SOFTWARE'].startswith('Development'):
+    pipeline._TEST_MODE = True
   if pipeline._TEST_MODE:
     return None
 


### PR DESCRIPTION
Per @rtshadow's comment on #72, enable TEST_MODE when in dev_appserver to avoid an otherwise confusing and fatal error later.